### PR TITLE
Nissix plugin scope-packages on @wix/wix-renovate-bot

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "chai": "~4.1.0",
     "husky": "^1.3.1",
     "lint-staged": "^8.1.5",
-    "yoshi": "^4.1.0",
+    "@wix/yoshi": "^4.1.0",
     "@wix/wix-bootstrap-testkit": "latest",
     "@wix/wix-config-emitter": "latest",
     "@wix/wix-rpc-testkit": "latest"

--- a/wallaby.js
+++ b/wallaby.js
@@ -1,1 +1,1 @@
-module.exports = require('yoshi/config/wallaby-mocha');
+module.exports = require('@wix/yoshi/config/wallaby-mocha');


### PR DESCRIPTION
Hi, I'm Nissix, the automated PR bot!

Wix is moving its internal packages to the @wix scope (but still in the internal registry). Publishing new unscoped internal packages is no longer allowed, and all existing packages are moving to @wix. This means changing package names, and also all usages of those packages to their @wix scope version.

This PR is an automatic codemod that moves all of your packages to @wix scope, and changes any usages (`pacakge.json`, imports, requires, etc..) to their @wix version.

| :bangbang: | This codemod is best-effort! Meaning it may not have found and fixed all usages, but it did change your package.jsons. So go over the changes carefully and test this version carefully  |
| :--------: | :----------------------------------------------------------------------------------------------------- |

If you want to know why we don't support publishing unscoped to the internal registry, check out this article on [Dependency Confusion](https://medium.com/@alex.birsan/dependency-confusion-4a5d60fec610)

If you are unsure, need help or have questions, reach us at #wix-scope-migration

Error Log:
npx: installed 234 in 6.68s



Output Log:
Migrating package "@wix/wix-renovate-bot" in .


## Migration from non scope to @wix/scoped packages
> /tmp/f6b7aa3464d7a8fc66d2e6ff278ddf83

#### rename package.json dependencies/dev/bundled/peer/optional, jest & eslintConfig
```
package.json
```

#### replace import/require in js/ts files
```
wallaby.js
```

